### PR TITLE
Fix optional chaining for asset size calculation

### DIFF
--- a/src/lib/get-asset-hash.ts
+++ b/src/lib/get-asset-hash.ts
@@ -23,5 +23,7 @@ export function getAssetHash(asset: Asset): string | null {
         return null
     }
 
-    return crypto.createHash('md5').update(Buffer.from(asset.source.source())).digest('hex')
+    return asset.source
+        ? crypto.createHash('md5').update(Buffer.from(asset.source.source())).digest('hex')
+        : null
 }

--- a/src/lib/get-manifest-entries-from-compilation.ts
+++ b/src/lib/get-manifest-entries-from-compilation.ts
@@ -212,7 +212,7 @@ export async function getManifestEntriesFromCompilation(
         return {
             file: resolveWebpackURL(publicPath as string, asset.name),
             hash: getAssetHash(asset),
-            size: asset.source.size() || 0
+            size: asset?.source.size() || 0
         } as FileDetails
     })
 

--- a/test/node/v5/get-manifest-entries-from-compilation.test.ts
+++ b/test/node/v5/get-manifest-entries-from-compilation.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { getManifestEntriesFromCompilation } from '../../../src/lib/get-manifest-entries-from-compilation'
+
+describe('getManifestEntriesFromCompilation size fallback', () => {
+    it('uses 0 when asset.source is undefined', async () => {
+        const asset = {
+            name: 'file.js',
+            info: {}
+        } as any
+
+        const compilation = {
+            getAssets: () => [asset],
+            options: { output: { publicPath: '' } },
+            warnings: [],
+            entrypoints: new Map()
+        } as any
+
+        const { size, sortedEntries } = await getManifestEntriesFromCompilation(compilation, {} as any)
+
+        expect(size).toEqual(0)
+        expect(sortedEntries).toHaveLength(1)
+        expect(sortedEntries[0].url).toEqual('file.js')
+    })
+})


### PR DESCRIPTION
In some cases, the source object will be undefined and an error will be thrown when running build script